### PR TITLE
Fix azure-data-tables readme file broken link issue

### DIFF
--- a/sdk/tables/azure-data-tables/README.md
+++ b/sdk/tables/azure-data-tables/README.md
@@ -137,7 +137,7 @@ Common uses of the Tables service include:
 
 - [Authenticate a client](#authenticate-a-client)
   - [Authenticate with a Connection String](#authenticate-with-a-connection-string)
-  - [Authenticate with a Named Key](#authenticate-with-a-named-key)
+  - [Authenticate with a Shared Key](#authenticate-with-a-shared-key)
   - [Authenticate with a Shared Access Signature (SAS)](#authenticate-with-a-shared-access-signature-sas)
 - [Create, List, and Delete Azure tables](#create-list-and-delete-azure-tables)
   - [Construct a `TableServiceClient`](#construct-a-tableserviceclient)


### PR DESCRIPTION
Changed the "Authenticate with a ~Named~ Key" to "Authenticate with a Shared Key" and fixed the broken link

Resolves #25029